### PR TITLE
Slim down the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,13 +20,13 @@ RUN mix local.hex --force && \
     mix local.rebar --force
 
 # set build ENV
-ENV MIX_ENV="prod"
-ENV ERL_FLAGS="+JPperf true"
+ENV MIX_ENV="prod" \
+    ERL_FLAGS="+JPperf true"
 
 # install mix dependencies
 COPY mix.exs mix.lock ./
-RUN mix deps.get --only $MIX_ENV
-RUN mkdir config
+RUN mix deps.get --only $MIX_ENV && \
+    mkdir config
 
 # copy compile-time config files before we compile dependencies
 # to ensure any relevant config change will trigger the dependencies
@@ -50,15 +50,13 @@ FROM ${RUNNER_IMAGE}
 
 RUN apk add --no-cache ca-certificates git libstdc++ openssl ncurses
 
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8 \
+    MIX_ENV=prod
 
 WORKDIR "/app"
 RUN chown nobody /app
-
-# set runner ENV
-ENV MIX_ENV="prod"
 
 # Only copy the final release from the build stage
 COPY --from=builder --chown=nobody:root /app/_build/${MIX_ENV}/rel/ ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,15 @@
 
 ARG ELIXIR_VERSION=1.17.0
 ARG OTP_VERSION=27.0
-ARG DEBIAN_VERSION=bookworm-20240612
+ARG ALPINE_VERSION=3.19.1
 
-ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
-ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
+ARG BUILDER_IMAGE="docker.io/hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-alpine-${ALPINE_VERSION}"
+ARG RUNNER_IMAGE="docker.io/library/alpine:${ALPINE_VERSION}"
 
 FROM ${BUILDER_IMAGE} as builder
 
 # install build dependencies
-RUN apt-get update -y && apt-get install -y build-essential git \
-    && apt-get clean && rm -f /var/lib/apt/lists/*_*
+RUN apk add --no-cache git
 
 # prepare build dir
 WORKDIR /app
@@ -49,12 +48,7 @@ RUN mix release
 # the compiled release and other runtime necessities
 FROM ${RUNNER_IMAGE}
 
-RUN apt-get update -y && \
-  apt-get install -y libstdc++6 openssl libncurses5 locales ca-certificates git \
-  && apt-get clean && rm -f /var/lib/apt/lists/*_*
-
-# Set the locale
-RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+RUN apk add --no-cache ca-certificates git libstdc++ openssl ncurses
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en


### PR DESCRIPTION
This PR slims down the Docker image from 381 MB to 137 MB.

It also reduces the amount of build stages.
